### PR TITLE
Remove protagonist dependency and upgrade dredd version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "test": "test"
   },
   "dependencies": {
-    "dredd": "^0.3.9",
-    "protagonist": "^0.12.1"
+    "dredd": "^0.3.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,10 @@
     "grunt-contrib-jshint": "^0.9.2",
     "grunt-contrib-clean": "^0.5.0",
     "grunt-contrib-nodeunit": "^0.3.3",
-    "grunt": "~0.4.5"
+    "grunt": ">=0.4.5"
+  },
+  "peerDependencies": {
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "grunt-contrib-jshint": "^0.9.2",
     "grunt-contrib-clean": "^0.5.0",
-    "grunt-contrib-nodeunit": "^0.3.3",
+    "grunt-contrib-nodeunit": "^0.3.3"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "test": "test"
   },
   "dependencies": {
-    "dredd": "^0.3.9"
+    "dredd": "~0.3.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "test": "test"
   },
   "dependencies": {
-    "dredd": "~0.3.9"
+    "dredd": "^1.0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "grunt-contrib-jshint": "^0.9.2",
     "grunt-contrib-clean": "^0.5.0",
     "grunt-contrib-nodeunit": "^0.3.3",
-    "grunt": "~0.4.5"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"

--- a/package.json
+++ b/package.json
@@ -26,10 +26,8 @@
   "devDependencies": {
     "grunt-contrib-jshint": "^0.9.2",
     "grunt-contrib-clean": "^0.5.0",
-    "grunt-contrib-nodeunit": "^0.3.3"
-  },
-  "peerDependencies": {
-    "grunt": ">=0.4.0"
+    "grunt-contrib-nodeunit": "^0.3.3",
+    "grunt": "~0.4.5"
   },
   "keywords": [
     "gruntplugin"


### PR DESCRIPTION
Hello!

Thanks for creating this very useful wrapper for dredd :) 

So I ran into a couple of issues when trying to use it and noticed a couple of things:
- the version of dredd is outdated
- the protagonist dependency is not needed since dredd already declares it.
